### PR TITLE
Use HTTPS only for GHG observability system

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=arm64 grafana/grafana:latest
 
 # List of plugins to install...
-ENV GF_INSTALL_PLUGINS=grafana-x-ray-datasource
+ENV GF_INSTALL_PLUGINS=grafana-x-ray-datasource,grafana-athena-datasource
 
 ADD provisioning/. /usr/local/grafana/provisioning
 

--- a/grafana/provisioning/datasources/athena.yaml
+++ b/grafana/provisioning/datasources/athena.yaml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Athena
+    type: grafana-athena-datasource
+    jsonData:
+      authType: default
+      defaultRegion: $AWS_REGION

--- a/stacks/grafana.py
+++ b/stacks/grafana.py
@@ -89,7 +89,6 @@ class GrafanaStack(Stack):
         # Add environment variables to container
         env: EcsEnv = {
             envify("paths.data"): mount_point.container_path,
-            "FOOBAR2": "BARFOO",
             envify("server.root_url"): (
                 f"https://{settings.grafana_domain_name}"
                 if settings.grafana_domain_name

--- a/stacks/settings.py
+++ b/stacks/settings.py
@@ -33,6 +33,9 @@ class Settings(BaseSettings):
 
     grafana_certificate_arn: Optional[str] = None
 
+    cloudfront_certificate_arn: Optional[str] = None
+
+
     permissions_boundary_arn: str
 
     # Github auth provider configuration


### PR DESCRIPTION
Use HTTPS for the origin associated with the observability system cloudfront
